### PR TITLE
Make staffDistribution push-able

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /docs/jsdoc/out/*
 /harmony/static/js/build/*
 /static/*
+env/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/IrwinLi2014/HarmonyLab.svg?branch=master)](https://travis-ci.org/IrwinLi2014/HarmonyLab)
-
 # Overview
 
 An Open-Source application for the study of music theory and keyboard skills that takes input from a MIDI keyboard and outputs staff notation. Various analytical vocabularies of melody and harmony are represented. As a practice aid and exercise platform that operates across aural, visual, and tactile domains, this tool accelerates the acquisition of fluency in certain fundamentals of tonal music.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/IrwinLi2014/HarmonyLab.svg?branch=master)](https://travis-ci.org/IrwinLi2014/HarmonyLab)
+
 # Overview
 
 An Open-Source application for the study of music theory and keyboard skills that takes input from a MIDI keyboard and outputs staff notation. Various analytical vocabularies of melody and harmony are represented. As a practice aid and exercise platform that operates across aural, visual, and tactile domains, this tool accelerates the acquisition of fluency in certain fundamentals of tonal music.

--- a/lab/static/js/src/components/app/exercise.js
+++ b/lab/static/js/src/components/app/exercise.js
@@ -60,10 +60,13 @@ define([
 	 */
 	AppExerciseComponent.prototype.getModels = function() {
 		var models = {};
-		models.inputChords = new ExerciseChordBank();
+		var definition = this.getExerciseDefinition()
 		models.midiDevice = new MidiDevice();
 		models.exerciseDefinition = new ExerciseDefinition({
-			definition: this.getExerciseDefinition()
+			definition: definition
+		});
+		models.inputChords = new ExerciseChordBank({
+			definition: definition
 		});
 		models.exerciseGrader = new ExerciseGrader();
 		models.exerciseContext = new ExerciseContext({

--- a/lab/static/js/src/models/chord.js
+++ b/lab/static/js/src/models/chord.js
@@ -13,12 +13,6 @@ define([
 	
 	var VOICE_COUNT_FOR_KEYBOARD_STYLE = Config.get('general.voiceCountForKeyboardStyle');
 
-	// HELP!!!
-	// if(this.exerciseContext) {
-		// var STAFF_DISTRIBUTION = this.exerciseContext.getDefinition().getStaffDistribution();
-	// }else {
-	// }
-
 	/**
 	 * Creates an instance of a chord.
 	 *
@@ -35,6 +29,9 @@ define([
 	 */
 	var Chord = function(settings) {
 		this.settings = settings || {};
+		if(this.settings.definition) {
+			STAFF_DISTRIBUTION = this.settings.definition.staffDistribution;
+		}
 		this.init();
 	};
 

--- a/lab/static/js/src/models/chord_bank.js
+++ b/lab/static/js/src/models/chord_bank.js
@@ -231,7 +231,7 @@ define([
 		 * @return {Chord}
 		 */
 		makeChord: function() {
-			return new Chord();
+			return new Chord(this.settings);
 		},
 		/**
 		 * Returns true if any chords in the bank are sustained.


### PR DESCRIPTION
It turns out that making staffDistribution push-able was very simple. The exerciseDefinition that has the configuration settings from the exercise is never sent to the `chord.js`.

To fix this, I modified the initialization of `models.inputChords` in `exercise.js` to include the exercise definition. `models.inputChords` initializes an `ExerciseChordBank` (exercise_chord_bank.js`), which chain initializes a `ChordBank` (`chord_bank.js`) which creates new `Chords` with the exercise definition passed as a `settings` parameter for the first chord creation.

The `STAFF_DISTRIBUTION` variable is set in the first `chord` initialization.

See commit `05252e2` "Made staffDistribution pushable" for details.