### PR TITLE
Pushable rhythmic notation of exercises

### DIFF
--- a/lab/static/js/src/components/app/exercise.js
+++ b/lab/static/js/src/components/app/exercise.js
@@ -65,8 +65,9 @@ define([
 		models.exerciseDefinition = new ExerciseDefinition({
 			definition: definition
 		});
+		// push exercise-wide features through here
 		models.inputChords = new ExerciseChordBank({
-			definition: definition
+			staffDistribution: definition.staffDistribution
 		});
 		models.exerciseGrader = new ExerciseGrader();
 		models.exerciseContext = new ExerciseContext({

--- a/lab/static/js/src/models/chord.js
+++ b/lab/static/js/src/models/chord.js
@@ -29,8 +29,8 @@ define([
 	 */
 	var Chord = function(settings) {
 		this.settings = settings || {};
-		if(this.settings.definition) {
-			STAFF_DISTRIBUTION = this.settings.definition.staffDistribution;
+		if(this.settings.staffDistribution) {
+			STAFF_DISTRIBUTION = this.settings.staffDistribution;
 		}
 		this.init();
 	};
@@ -42,7 +42,12 @@ define([
 		 * @return undefined
 		 */
 		init: function() {
-			this._rhythmValue = false;
+			/**
+			 * Rhythm value for specific note. Value can be "w", "h", or "q"
+			 * @type {string}
+			 * @protected
+			 */
+			this._rhythmValue = null;
 			/**
 			 * Container for the notes that are active.
 			 * @type {object}
@@ -74,6 +79,11 @@ define([
 			 * @protected
 			 */
 			this._noteProps = {};
+
+			// initialize rhythm value
+			if("rhythm" in this.settings) {
+				this._rhythmValue = this.settings.rhythm;
+			}
 
 			// initialize notes that should be on
 			if("notes" in this.settings) {

--- a/lab/static/js/src/models/exercise_context.js
+++ b/lab/static/js/src/models/exercise_context.js
@@ -422,10 +422,11 @@ define([
 			var exercise_chords = [];
 			var problems = this.definition.getProblems();
 			var CORRECT = this.grader.STATE.CORRECT;
-			var g_problem, chord, chords; 
+			var g_problem, chord, chords, rhythm;
 
 			for(var i = 0, len = problems.length; i < len; i++) {
 				notes = problems[i].visible;
+				rhythm = problems[i].rhythm;
 				g_problem = false;
 				if(this.graded !== false && this.graded.problems[i]) {
 					g_problem = this.graded.problems[i];
@@ -436,7 +437,7 @@ define([
 					notes = _.uniq(notes);
 				}
 
-				chord = new ExerciseChord({ notes: notes });
+				chord = new ExerciseChord({ notes: notes, rhythm: rhythm });
 
 				if(g_problem) {
 					_.each(g_problem.count, function(notes, correctness) {
@@ -464,10 +465,13 @@ define([
 			var notes = [];
 			var exercise_chords = []; 
 			var chords;
+			var rhythm;
 
 			for(var i = 0, len = problems.length; i < len; i++) {
 				notes = problems[i].notes;
-				chord = new ExerciseChord({ notes: notes });
+				rhythm = problems[i].rhythm;
+				// we can push any notewise features through this entry point!
+				chord = new ExerciseChord({ notes: notes, rhythm: rhythm });
 				exercise_chords.push(chord);
 			}
 

--- a/lab/static/js/src/models/exercise_definition.js
+++ b/lab/static/js/src/models/exercise_definition.js
@@ -188,8 +188,8 @@ define(['lodash'], function(_) {
 			// normalize the internal representation of each chord in the
 			// set of problems to have VISIBLE/HIDDEN parts
 			problems = _.map(problems, function(chord, index) {
-				var normalized = {"visible":[], "hidden":[],"notes":[]};
-				// var normalized = {"visible":[], "hidden":[],"notes":[],"rhythm":false};
+				// var normalized = {"visible":[], "hidden":[],"notes":[]};
+				var normalized = {"visible":[], "hidden":[],"notes":[],"rhythm":null};
 
 				if(_.isArray(chord)) {
 					normalized.visible = chord;
@@ -211,9 +211,9 @@ define(['lodash'], function(_) {
 				normalized.hidden = ExerciseDefinition.sortNotes(normalized.hidden);
 				normalized.notes = ExerciseDefinition.sortNotes(normalized.notes);
 
-				// if(chord.hasOwnProperty("rhythm")) {
-				// 	normalized.rhythm = chord.rhythm;
-				// }
+				if(chord.hasOwnProperty("rhythmValue")) {
+					normalized.rhythm = chord.rhythmValue;
+				}
 
 				return normalized;
 			});


### PR DESCRIPTION
Finished implementing pushable rhythmic notation and improved overhead for by pushing only staff distribution instead of entire settings object.

NOTE: This PR does not include any updates to meter and aesthetics.

When `lab/static/js/src/components/app/exercise.js` creates `models.inputChords` as a new `ExerciseChordBank`, it creates an empty chord bank with just the exercise-wide features (only pushable feature is staffDistribution for now).

Later, when `exercise.js` creates `models.exerciseContext` as a new `ExerciseContext`, it uses the data from `models.exerciseDefinition` to generate the chords. We can add specific modifications for each chord by adding the feature to the `parse()` function in `exercise_definition.js`. We can then use the `rhythm` information to generate `ExerciseChords` in `ExerciseContext` to be used in `chord.js`.

![image](https://user-images.githubusercontent.com/14365808/36349917-0bc545da-145c-11e8-9ffb-411d91452f87.png)
