### PR TITLE
add signals and management command to remove microseconds from "creat…

### DIFF
--- a/apps/exercises/management/commands/truncate_timestamps.py
+++ b/apps/exercises/management/commands/truncate_timestamps.py
@@ -1,0 +1,20 @@
+from django.core.management import BaseCommand
+from django.db import connections
+
+from apps.exercises.models import PerformanceData, Exercise, Playlist, Course
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        models = [Exercise, Playlist, Course, PerformanceData]
+        with connections['default'].cursor() as cursor:
+            for model in models:
+                cursor.execute(
+                    "UPDATE {} "
+                    "SET created = DATE_TRUNC('second', created), updated = DATE_TRUNC('second', updated) ".format(
+                        model._meta.db_table
+                    )
+                )
+        self.stdout.write(
+            self.style.SUCCESS('Successfully removed microseconds from timestamps.')
+        )


### PR DESCRIPTION
…ed" and "updated" fields. run this command after deploy: python manage.py truncate_timestamps